### PR TITLE
add scale query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ You should have access to an OpenShift cluster and be logged in with the
    $ curl http://`oc get routes/vertx-sparkpi --template='{{.spec.host}}'`/sparkpi
    Pi is roughly 3.140480
    ```
+
+### Optional parameter
+
+If you would like to change the number of samples that are used to calculate
+Pi, you can specify them by adding the `scale` argument to your request
+, for example:
+
+```bash
+$ curl http://`oc get routes/vertx-sparkpi --template='{{.spec.host}}'`/sparkpi?scale=10
+Pi is roughly 3.141749
+```

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
@@ -9,10 +9,10 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
 public class SparkPiProducer implements Serializable {
-    public String GetPi() {
+    public String GetPi(int scale) {
         JavaSparkContext jsc = SparkContextProvider.getContext();
 
-        int slices = 2;
+        int slices = scale;
         int n = 100000 * slices;
         List<Integer> l = new ArrayList<Integer>(n);
         for (int i = 0; i < n; i++) {

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
@@ -11,6 +11,7 @@ import org.apache.log4j.*;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.Vertx;
@@ -73,9 +74,14 @@ public class SparkPiVerticle extends AbstractVerticle {
 
     router.route("/sparkpi").handler(routingContext -> {
       HttpServerResponse response = routingContext.response();
+      HttpServerRequest request = routingContext.request();
+      int scale = 2;
+      if (request.params().get("scale") != null) {
+          scale = Integer.parseInt(request.params().get("scale"));
+      }
       response
           .putHeader("content-type", "text/html")
-          .end(pi.GetPi());
+          .end(pi.GetPi(scale));
     });
 
     vertx


### PR DESCRIPTION
This change adds the scale query parameter detection to the sparkpi route, with a default value of 2.