### PR TITLE
Some improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java2</artifactId>
+      <version>${vertx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
       <version>${vertx.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         </executions>
         <configuration>
           <redeploy>true</redeploy>
+          <classifier>vertx</classifier>
           <verticle>io.radanalytics.examples.vertx.SparkPiVerticle</verticle>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,45 +50,22 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <groupId>io.reactiverse</groupId>
+        <artifactId>vertx-maven-plugin</artifactId>
+        <version>1.0.15</version>
         <executions>
           <execution>
-            <phase>package</phase>
+            <id>vmp</id>
             <goals>
-              <goal>shade</goal>
+              <goal>initialize</goal>
+              <goal>package</goal>
             </goals>
-            <configuration>
-               <shadedArtifactAttached>true</shadedArtifactAttached>
-               <shadedClassifierName>stand-alone</shadedClassifierName>
-               <filters>
-                  <filter>
-                     <!-- Exclude files that sign a jar
-                          (one or multiple of the dependencies),
-                          SecurityException otherwise.
-                     -->
-                     <artifact>*:*</artifact>
-                        <excludes>
-                           <exclude>META-INF/*.SF</exclude>
-                           <exclude>META-INF/*.RSA</exclude>
-                           <exclude>META-INF/*.INF</exclude>
-                        </excludes>
-                  </filter>
-               </filters>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Main-Class>io.vertx.core.Launcher</Main-Class>
-                    <Main-Verticle>io.radanalytics.examples.vertx.SparkPiVerticle</Main-Verticle>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-              <artifactSet/>
-              <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-vertx.jar</outputFile>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <redeploy>true</redeploy>
+          <verticle>io.radanalytics.examples.vertx.SparkPiVerticle</verticle>
+        </configuration>
       </plugin>
     </plugins>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Be careful modifying these due to joint netty dependencies -->
-    <vertx.version>3.2.1</vertx.version>
+    <vertx.version>3.5.3</vertx.version>
     <spark.version>2.3.0</spark.version>
     <doc.skip>true</doc.skip>
   </properties>

--- a/src/main/java/io/radanalytics/examples/vertx/SparkContextProvider.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkContextProvider.java
@@ -12,7 +12,6 @@ public class SparkContextProvider {
 
     private SparkConf sparkConf;
     private JavaSparkContext sparkContext;
-    private String jarFile;
 
     private SparkContextProvider() {}
 

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
@@ -1,44 +1,34 @@
 package io.radanalytics.examples.vertx;
 
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.Single;
-import io.vertx.reactivex.core.Vertx;
-import org.apache.spark.api.java.function.Function;
-import org.apache.spark.api.java.function.Function2;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-
 public class SparkPiProducer implements Serializable {
-    private final Vertx vertx;
 
-    public SparkPiProducer(Vertx vertx) {
-        this.vertx = vertx;
-    }
 
-    public Single<String> getPi(int scale) {
+    public String getPi(int scale) {
         JavaSparkContext jsc = SparkContextProvider.getContext();
         int slices = scale;
         int n = 100000 * slices;
-        return vertx.rxExecuteBlocking(
-                future -> {
-                    List<Integer> l = new ArrayList<>(n);
-                    for (int i = 0; i < n; i++) {
-                        l.add(i);
-                    }
 
-                    JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
+        List<Integer> l = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            l.add(i);
+        }
 
-                    int count = dataSet.map(integer -> {
-                        double x = Math.random() * 2 - 1;
-                        double y = Math.random() * 2 - 1;
-                        return (x * x + y * y < 1) ? 1 : 0;
-                    }).reduce((integer, integer2) -> integer + integer2);
-                    future.complete("Pi is rouuuughly " + 4.0 * count / n);
-                }
-        );
+        JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
+
+        int count = dataSet.map(integer -> {
+            double x = Math.random() * 2 - 1;
+            double y = Math.random() * 2 - 1;
+            return (x * x + y * y < 1) ? 1 : 0;
+        }).reduce((integer, integer2) -> integer + integer2);
+
+        return "Pi is rouuuughly " + 4.0 * count / n;
 
     }
 }

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiProducer.java
@@ -3,32 +3,42 @@ package io.radanalytics.examples.vertx;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.reactivex.Single;
+import io.vertx.reactivex.core.Vertx;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
 public class SparkPiProducer implements Serializable {
-    public String GetPi(int scale) {
-        JavaSparkContext jsc = SparkContextProvider.getContext();
+    private final Vertx vertx;
 
+    public SparkPiProducer(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    public Single<String> getPi(int scale) {
+        JavaSparkContext jsc = SparkContextProvider.getContext();
         int slices = scale;
         int n = 100000 * slices;
-        List<Integer> l = new ArrayList<Integer>(n);
-        for (int i = 0; i < n; i++) {
-            l.add(i);
-        }
+        return vertx.rxExecuteBlocking(
+                future -> {
+                    List<Integer> l = new ArrayList<>(n);
+                    for (int i = 0; i < n; i++) {
+                        l.add(i);
+                    }
 
-        JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
+                    JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
 
-        int count = dataSet.map(integer -> {
-            double x = Math.random() * 2 - 1;
-            double y = Math.random() * 2 - 1;
-            return (x * x + y * y < 1) ? 1 : 0;
-        }).reduce((integer, integer2) -> integer + integer2);
+                    int count = dataSet.map(integer -> {
+                        double x = Math.random() * 2 - 1;
+                        double y = Math.random() * 2 - 1;
+                        return (x * x + y * y < 1) ? 1 : 0;
+                    }).reduce((integer, integer2) -> integer + integer2);
+                    future.complete("Pi is rouuuughly " + 4.0 * count / n);
+                }
+        );
 
-        String ret = "Pi is rouuuughly " + 4.0 * count / n;
-
-        return ret;
     }
 }

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
@@ -1,102 +1,80 @@
 package io.radanalytics.examples.vertx;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
-import org.apache.log4j.*;
-
-import io.vertx.core.AbstractVerticle;
+import io.reactivex.Single;
 import io.vertx.core.Future;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.Vertx;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
-import io.vertx.ext.web.handler.StaticHandler;
+import io.vertx.reactivex.core.AbstractVerticle;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpServer;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import io.vertx.reactivex.ext.web.Router;
+import org.apache.log4j.Logger;
 
 public class SparkPiVerticle extends AbstractVerticle {
 
   private static final Logger log = Logger.getRootLogger();
-  private Properties prop = null;
+  private JsonObject prop = null;
+  private SparkPiProducer pi;
 
-  // vertx-config has more exotic options using Futures
+    // vertx-config has more exotic options using Futures
   // and AsyncResult handlers, but this is all we need
-  private String loadJarProperty() {
-    if (null==prop) {
-     prop = new Properties();
+  private Single<String> loadJarProperty() {
+    if (prop != null) {
+     return Single.just(prop.getString("jarfile"));
     }
-    String jarFile = "";
-    try {
-      InputStream inputStream = getClass().getClassLoader()
-                   .getResourceAsStream("sparkpi.properties");
-      prop.load(inputStream);
-      jarFile = prop.getProperty("sparkpi.jarfile");
-    } catch (IOException e) {
-        e.printStackTrace();
-    }
-    return jarFile;
+
+    return vertx.fileSystem().rxReadFile("sparkip.json")
+            .map(Buffer::toJsonObject)
+            .doOnSuccess(json -> prop = json)
+            .map(json -> json.getString("jarfile"));
   }
 
   @Override
   public void start(Future<Void> fut) {
     // Create a router object.
     Router router = Router.router(vertx);
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      public void run() {
-        vertx.close();
-      }
-    });
+      router.route("/").handler(routingContext -> {
+          HttpServerResponse response = routingContext.response();
+          response
+                  .putHeader("content-type", "text/html")
+                  .end("Java Vert.x SparkPi server running. Add the 'sparkpi' route to this URL to invoke the app.");
+      });
 
-    String jarFile = this.loadJarProperty();
-    log.info("SparkPi submit jar is: "+jarFile);
+      router.route("/sparkpi").handler(routingContext -> {
+          HttpServerResponse response = routingContext.response();
+          HttpServerRequest request = routingContext.request();
+          int scale = 2;
+          if (request.params().get("scale") != null) {
+              scale = Integer.parseInt(request.params().get("scale"));
+          }
 
-    // init our Spark context
-    if (!SparkContextProvider.init(jarFile)) {
-        // masterURL probably not set
-        log.error("This application is intended to be run as an oshinko S2I.");
-        vertx.close();
-        System.exit(1);
-    }
-    SparkPiProducer pi = new SparkPiProducer();
+          pi.getPi(scale)
+                  .subscribe(
+                      res -> response
+                          .putHeader("content-type", "text/html")
+                          .end(res),
+                      routingContext::fail);
 
-    router.route("/").handler(routingContext -> {
-      HttpServerResponse response = routingContext.response();
-      response
-          .putHeader("content-type", "text/html")
-          .end("Java Vert.x SparkPi server running. Add the 'sparkpi' route to this URL to invoke the app.");
-    });
+      });
 
-    router.route("/sparkpi").handler(routingContext -> {
-      HttpServerResponse response = routingContext.response();
-      HttpServerRequest request = routingContext.request();
-      int scale = 2;
-      if (request.params().get("scale") != null) {
-          scale = Integer.parseInt(request.params().get("scale"));
-      }
-      response
-          .putHeader("content-type", "text/html")
-          .end(pi.GetPi(scale));
-    });
+    Single<String> loaded = loadJarProperty()
+            .doOnError(x -> log.error("This application is intended to be run as an oshinko S2I."))
+            .doOnSuccess(s -> {
+                log.info("SparkPi submit jar is: " + s);
+                pi = new SparkPiProducer(vertx);
+            });
 
-    vertx
-        .createHttpServer()
-        .requestHandler(router::accept)
-        .listen(
-            // here developers can make use of vertx-config if they like
-            this.config().getInteger("http.port", 8080),
-            result -> {
-              if (result.succeeded()) {
-                fut.complete();
-              } else {
-                fut.fail(result.cause());
-              }
-            }
-        );
+      Single<HttpServer> listening = vertx
+              .createHttpServer()
+              .requestHandler(router::accept)
+              .rxListen(this.config().getInteger("http.port", 8080));
+
+      Single.merge(loaded, listening)
+              .ignoreElements()
+              .subscribe(
+                      fut::complete,
+                      fut::fail
+              );
   }
 }

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
@@ -59,9 +59,11 @@ public class SparkPiVerticle extends AbstractVerticle {
       });
 
     Single<String> loaded = loadJarProperty()
-            .doOnError(x -> log.error("This application is intended to be run as an oshinko S2I."))
-            .doOnSuccess(s -> {
-                log.info("SparkPi submit jar is: " + s);
+            .doOnSuccess(jarFile -> {
+                log.info("SparkPi submit jar is: " + jarFile);
+                if (!SparkContextProvider.init(jarFile)) {
+                    throw new RuntimeException("This application is intended to be run as an oshinko S2I.");
+                }
                 pi = new SparkPiProducer(vertx);
             });
 

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
@@ -49,12 +49,13 @@ public class SparkPiVerticle extends AbstractVerticle {
               scale = Integer.parseInt(request.params().get("scale"));
           }
 
-          pi.getPi(scale)
-                  .subscribe(
-                      res -> response
-                          .putHeader("content-type", "text/html")
-                          .end(res),
-                      routingContext::fail);
+          int computedScale = scale;
+          vertx.<String>rxExecuteBlocking(future -> future.complete(pi.getPi(computedScale)))
+              .subscribe(
+                  res -> response
+                      .putHeader("content-type", "text/html")
+                      .end(res),
+                  routingContext::fail);
 
       });
 
@@ -64,7 +65,7 @@ public class SparkPiVerticle extends AbstractVerticle {
                 if (!SparkContextProvider.init(jarFile)) {
                     throw new RuntimeException("This application is intended to be run as an oshinko S2I.");
                 }
-                pi = new SparkPiProducer(vertx);
+                pi = new SparkPiProducer();
             });
 
       Single<HttpServer> listening = vertx

--- a/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
+++ b/src/main/java/io/radanalytics/examples/vertx/SparkPiVerticle.java
@@ -24,7 +24,7 @@ public class SparkPiVerticle extends AbstractVerticle {
      return Single.just(prop.getString("jarfile"));
     }
 
-    return vertx.fileSystem().rxReadFile("sparkip.json")
+    return vertx.fileSystem().rxReadFile("sparkpi.json")
             .map(Buffer::toJsonObject)
             .doOnSuccess(json -> prop = json)
             .map(json -> json.getString("jarfile"));

--- a/src/main/resources/sparkpi.json
+++ b/src/main/resources/sparkpi.json
@@ -1,0 +1,3 @@
+{
+  "jarfile":"/opt/app-root/src/@project.name@-@project.version@.jar"
+}

--- a/src/main/resources/sparkpi.properties
+++ b/src/main/resources/sparkpi.properties
@@ -1,1 +1,0 @@
-sparkpi.jarfile=/opt/app-root/src/@project.name@-@project.version@.jar


### PR DESCRIPTION
This PR:

* updates the vert.x version
* uses reactive programming
* replaces the properties reading to use JSON and async file resolver
* moves the actual computation on a worker thread
* use the Vert.x Maven plugin

The Vert.x Maven Plugin has been configured to use the `vertx` classifier, this is not required. But it would slightly change the template used for the deployment. I let you decide.

BTW, the fat jar is kind of _fat_. Did you try pruning the dependencies? Adding the `provided` scope to some dependency may significantly reduce the jar size. However, we need to be sure that either these dependencies are not used or provided by the image.